### PR TITLE
fix appending of the apikey to the query url

### DIFF
--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -49,8 +49,8 @@ const url = (params) => {
     } else {
       url += '&'
     }
-    queryString += `apikey=${apikey}`;
-    url += queryString;
+
+    url += `apikey=${apikey}`;
 
     return url;
 }


### PR DESCRIPTION
Previously the apikey was attached to the queryString and the queryString to the url.
In case of parameters, this resulted in duplicating the parameters and attaching the apikey without the '&' symbol.
That was the reason for the error message
`'Error Message': 'Invalid API KEY. Please retry or visit our documentation to create one FREE https://financialmodelingprep.com/developer/docs'`
This pr fixes it attaching the apikey at the end of the url.