### PR TITLE
Fixed and added endpoints with support for API v4 (default v3)

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+# Ignore files:
+*.md

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ current_price()                                             // /stock/real-time-
 history({start_date, end_date, limit, type} = {})           // /historical-price-full/{ticker}?{opts}
 dividend_history({start_date, end_date, limit, type} = {})  // /historical-price-full/stock_dividend/{ticker}?{opts}
 split_history({start_date, end_date, limit, type} = {})     // /historical-price-full/stock_split/{ticker}?{opts}
+earnings({limit} = {})                                      // /historical/earning_calendar/{ticker}?{opts}
 
 financial.income(period = 'annual')                         // /financials/income-statement
 financial.balancesheet(period = 'annual')                   // /financials/balance-sheet-statement

--- a/README.md
+++ b/README.md
@@ -57,11 +57,11 @@ dividend_history({start_date, end_date, limit, type} = {})  // /historical-price
 split_history({start_date, end_date, limit, type} = {})     // /historical-price-full/stock_split/{ticker}?{opts}
 earnings({limit} = {})                                      // /historical/earning_calendar/{ticker}?{opts}
 
-financial.income(period = 'annual')                         // /financials/income-statement
-financial.balancesheet(period = 'annual')                   // /financials/balance-sheet-statement
-financial.cashflow(period = 'annual')                       // /financials/cash-flow-statement
-financial.metrics(period = 'annual')                        // /company-key-metrics
-financial.growth(period = 'annual')                         // /financial-statement-growth
+financial.income(period = 'annual')                         // /income-statement
+financial.balancesheet(period = 'annual')                   // /balance-sheet-statement
+financial.cashflow(period = 'annual')                       // /cash-flow-statement
+financial.metrics(period = 'annual')                        // /key-metrics
+financial.growth(period = 'annual')                         // /financial-growth
 financial.ratios()                                          // /financial-ratios
 ```
 \* The `stock` parameter can either be pased as a string or an array of market tickers. These tickers can be found either by running search based on corporation name.

--- a/lib/financial.js
+++ b/lib/financial.js
@@ -5,11 +5,11 @@ const { makeRequest, generateJson } = require('./utilities');
 module.exports = (stock) => {
 
     return {
-        income: (period = 'annual') => makeRequest('financials/income-statement', generateJson(stock, { period: period })),
-        balance: (period = 'annual') => makeRequest('financials/balance-sheet-statement', generateJson(stock, { period: period })),
-        cashflow: (period = 'annual') => makeRequest('financials/cash-flow-statement', generateJson(stock, { period: period })),
+        income: (period = 'annual') => makeRequest('income-statement', generateJson(stock, { period: period })),
+        balance: (period = 'annual') => makeRequest('balance-sheet-statement', generateJson(stock, { period: period })),
+        cashflow: (period = 'annual') => makeRequest('cash-flow-statement', generateJson(stock, { period: period })),
         metrics: (period = 'annual') => makeRequest('key-metrics', generateJson(stock, { period: period })),
-        growth: (period = 'annual') => makeRequest('financial-statement-growth', generateJson(stock, { period: period })),
+        growth: (period = 'annual') => makeRequest('financial-growth', generateJson(stock, { period: period })),
         company_value: (period = 'annual') => makeRequest('enterprise-value', generateJson(stock, { period: period })),
         ratios: () => makeRequest('financial-ratios', generateJson(stock))
     }

--- a/lib/financial.js
+++ b/lib/financial.js
@@ -8,7 +8,7 @@ module.exports = (stock) => {
         income: (period = 'annual') => makeRequest('financials/income-statement', generateJson(stock, { period: period })),
         balance: (period = 'annual') => makeRequest('financials/balance-sheet-statement', generateJson(stock, { period: period })),
         cashflow: (period = 'annual') => makeRequest('financials/cash-flow-statement', generateJson(stock, { period: period })),
-        metrics: (period = 'annual') => makeRequest('company-key-metrics', generateJson(stock, { period: period })),
+        metrics: (period = 'annual') => makeRequest('key-metrics', generateJson(stock, { period: period })),
         growth: (period = 'annual') => makeRequest('financial-statement-growth', generateJson(stock, { period: period })),
         company_value: (period = 'annual') => makeRequest('enterprise-value', generateJson(stock, { period: period })),
         ratios: () => makeRequest('financial-ratios', generateJson(stock))

--- a/lib/stock.js
+++ b/lib/stock.js
@@ -16,6 +16,7 @@ module.exports = (stock) => {
         history: ({ start_date, end_date, data_type, limit } = {}) => makeRequest('historical-price-full', generateJson(stock, { from: start_date, to: end_date, serietype: data_type, timeseries: limit })),
         dividend_history: ({ start_date, end_date, data_type, limit } = {}) => makeRequest('historical-price-full/stock_dividend', generateJson(stock, { from: start_date, to: end_date, serietype: data_type, timeseries: limit })),
         split_history: ({ start_date, end_date, data_type, limit } = {}) => makeRequest('historical-price-full/stock_split', generateJson(stock, { from: start_date, to: end_date, serietype: data_type, timeseries: limit })),
+        earnings: ({ limit } = {}) => makeRequest('historical/earning_calendar', generateJson(stock, { limit: limit })),
 
         /* V4 endpoints. */
         outlook: () => makeRequest('company-outlook', generateJson(undefined, { symbol: stock }, 'v4')),

--- a/lib/stock.js
+++ b/lib/stock.js
@@ -11,6 +11,7 @@ module.exports = (stock) => {
         financial: financial(stock),
         rating: () => makeRequest('company/rating', generateJson(stock)),
         current_price: () => makeRequest('stock/real-time-price', generateJson(stock)),
+        key_metrics: () => makeRequest('key-metrics-ttm', generateJson(stock)),
 
         history: ({ start_date, end_date, data_type, limit } = {}) => makeRequest('historical-price-full', generateJson(stock, { from: start_date, to: end_date, serietype: data_type, timeseries: limit })),
         dividend_history: ({ start_date, end_date, data_type, limit } = {}) => makeRequest('historical-price-full/stock_dividend', generateJson(stock, { from: start_date, to: end_date, serietype: data_type, timeseries: limit })),

--- a/lib/stock.js
+++ b/lib/stock.js
@@ -11,6 +11,7 @@ module.exports = (stock) => {
         financial: financial(stock),
         rating: () => makeRequest('company/rating', generateJson(stock)),
         current_price: () => makeRequest('stock/real-time-price', generateJson(stock)),
+        target_consensus: () => makeRequest('price-target-consensus', generateJson(undefined, { symbol: stock }, 'v4')),
 
         history: ({ start_date, end_date, data_type, limit } = {}) => makeRequest('historical-price-full', generateJson(stock, { from: start_date, to: end_date, serietype: data_type, timeseries: limit })),
         dividend_history: ({ start_date, end_date, data_type, limit } = {}) => makeRequest('historical-price-full/stock_dividend', generateJson(stock, { from: start_date, to: end_date, serietype: data_type, timeseries: limit })),

--- a/lib/stock.js
+++ b/lib/stock.js
@@ -11,10 +11,13 @@ module.exports = (stock) => {
         financial: financial(stock),
         rating: () => makeRequest('company/rating', generateJson(stock)),
         current_price: () => makeRequest('stock/real-time-price', generateJson(stock)),
-        target_consensus: () => makeRequest('price-target-consensus', generateJson(undefined, { symbol: stock }, 'v4')),
 
         history: ({ start_date, end_date, data_type, limit } = {}) => makeRequest('historical-price-full', generateJson(stock, { from: start_date, to: end_date, serietype: data_type, timeseries: limit })),
         dividend_history: ({ start_date, end_date, data_type, limit } = {}) => makeRequest('historical-price-full/stock_dividend', generateJson(stock, { from: start_date, to: end_date, serietype: data_type, timeseries: limit })),
-        split_history: ({ start_date, end_date, data_type, limit } = {}) => makeRequest('historical-price-full/stock_split', generateJson(stock, { from: start_date, to: end_date, serietype: data_type, timeseries: limit }))
+        split_history: ({ start_date, end_date, data_type, limit } = {}) => makeRequest('historical-price-full/stock_split', generateJson(stock, { from: start_date, to: end_date, serietype: data_type, timeseries: limit })),
+
+        /* V4 endpoints. */
+        outlook: () => makeRequest('company-outlook', generateJson(undefined, { symbol: stock }, 'v4')),
+        target_consensus: () => makeRequest('price-target-consensus', generateJson(undefined, { symbol: stock }, 'v4')),
     }
 };

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -3,11 +3,13 @@
 const axios = require('axios')
 const auth = require("./auth");
 
-const baseURL = 'https://financialmodelingprep.com/api/v3/';
+const baseURL = 'https://financialmodelingprep.com/api/';
 
 /**
  * Creates the endpoint using the default base URL and adding the respective
  * path and query parameters to be requested by the API.
+ *
+ * Defaults to API version 3, which can be overwritten in the parameters.
  *
  * Future Use: Incase of querying a new database in the future, this is the
  * only function that would require modification for the most part to control how
@@ -23,7 +25,8 @@ const url = (params) => {
     let queryParameters = params['query'];
     let pathParameters = params['path'];
     let urlPath = params['urlPath'];
-    let url = baseURL;
+    let apiVersion = params['apiVersion'] || 'v3';
+    let url = baseURL + apiVersion + '/';
     let queryString = '';
     let apikey = auth.key;
     url += urlPath;
@@ -64,16 +67,19 @@ const url = (params) => {
  * @param {JsonObject} queryParam
  *      A JSON object that contains key value pairs to be added to the
  *      query parameters
+ * @param {String} apiVersion
+ *      A string that represents the API version
  *
  * @returns {JsonObject}
  *      A manageable JSON object that contains the respective query and path
  *      parameters which will be parsed by `url` function
  */
-function generateJson(pathParam, queryParam = undefined)
+function generateJson(pathParam, queryParam = undefined, apiVersion = undefined)
 {
     return {
         query: queryParam,
-        path: pathParam
+        path: pathParam,
+        apiVersion: apiVersion
     }
 }
 


### PR DESCRIPTION
Changes to add new API endpoints and resolve issue(s):

- Resolved (#28).
- Resolved (#29 ).
- Added support for API v4 with optional `apiVersion` parameter (default v3).
- Added company outlook endpoint (v4).
- Added target consensus endpoint (v4).
- Added key metrics TTM endpoint. 
